### PR TITLE
Little improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,11 @@ Adds "go to declaration" that works with modules declared elsewhere, and fallbac
 - Rewrite using Typescript
 
 #Contributing
-Anything is welcome!  
+dokkis:
+	- workspace.scan now is limited to ts and js files
+	- added support for multiple export symbol in one file 
+	- support for non default export
+	- support for interface, namespace and enum
+	- added warning notification if you try to import multiple times the same symbol
+	- added error notification if the plugin does not find the symbol
+	- added support for numbers in the symbol definition (example ClassName1)

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Adds "go to declaration" that works with modules declared elsewhere, and fallbac
 
 #Contributing
 dokkis:
-	- workspace.scan now is limited to ts and js files
-	- added support for multiple export symbol in one file 
-	- support for non default export
-	- support for interface, namespace and enum
-	- added warning notification if you try to import multiple times the same symbol
-	- added error notification if the plugin does not find the symbol
-	- added support for numbers in the symbol definition (example ClassName1)
+- workspace.scan now is limited to ts and js files
+- added support for multiple export symbol in one file 
+- support for non default export
+- support for interface, namespace and enum
+- added warning notification if you try to import multiple times the same symbol
+- added error notification if the plugin does not find the symbol
+- added support for numbers in the symbol definition (example ClassName1)


### PR DESCRIPTION
Hello,
I was just looking to this awesome Atom plugin to avoid to write the Typescript import directives by hands.

I just tried to make some improvements:
- workspace.scan now is limited to ts and js files
- added support for multiple export symbol in one file
- support for non default export
- support for interface, namespace and enum
- added warning notification if you try to import multiple times the same symbol
- added error notification if the plugin does not find the symbol
- added support for numbers in the symbol definition (example ClassName1)

Feel free to merge or not all or some of my improvements ;)

Thank you.
Have a nice day.

Antonio (a.k.a. dokkis)
