### PR TITLE
Fixed incorrect import paths in Windows

### DIFF
--- a/lib/typescript-import.coffee
+++ b/lib/typescript-import.coffee
@@ -88,7 +88,7 @@ module.exports = TypescriptImport =
       symbolLocation = @index[selection]
       if symbolLocation && selection
         fileFolder = path.resolve(filePath + '/..')
-        relative = path.relative(fileFolder, symbolLocation).replace(/\.(js|ts)$/, '');
+        relative = path.relative(fileFolder, symbolLocation).replace(/\.(js|ts)$/, '').replace(/\\/g, '/')
         importClause = "import #{selection} from './#{relative}';\n"
         @addImportStatement(importClause)
 #        editor.insertText(selection + "\nimport #{selection} from './#{relative}'")


### PR DESCRIPTION
path.relative was (correctly) returning Windows style backslash paths when running Atom on Windows. However this results in incorrect TypeScript import paths (which are always unix style forward slash
paths)

Before on Windows:

`import IWow from './..\..\..\foo\bar\IWow';`

After on Windows:

`import IWow from './../../../foo/bar/IWow';`
