### PR TITLE
Remove unnecessary relative root

### DIFF
--- a/lib/typescript-import.coffee
+++ b/lib/typescript-import.coffee
@@ -89,7 +89,7 @@ module.exports = TypescriptImport =
       if symbolLocation && selection
         fileFolder = path.resolve(filePath + '/..')
         relative = path.relative(fileFolder, symbolLocation).replace(/\.(js|ts)$/, '');
-		if relative[0] !== '.'
+		if relative[0] != '.'
 		  relative = './' + relative
         importClause = "import #{selection} from '#{relative}';\n"
         @addImportStatement(importClause)

--- a/lib/typescript-import.coffee
+++ b/lib/typescript-import.coffee
@@ -89,8 +89,8 @@ module.exports = TypescriptImport =
       if symbolLocation && selection
         fileFolder = path.resolve(filePath + '/..')
         relative = path.relative(fileFolder, symbolLocation).replace(/\.(js|ts)$/, '');
-		if relative[0] != '.'
-		  relative = './' + relative
+        if relative[0] != '.'
+          relative = './' + relative
         importClause = "import #{selection} from '#{relative}';\n"
         @addImportStatement(importClause)
 #        editor.insertText(selection + "\nimport #{selection} from './#{relative}'")

--- a/lib/typescript-import.coffee
+++ b/lib/typescript-import.coffee
@@ -89,7 +89,9 @@ module.exports = TypescriptImport =
       if symbolLocation && selection
         fileFolder = path.resolve(filePath + '/..')
         relative = path.relative(fileFolder, symbolLocation).replace(/\.(js|ts)$/, '');
-        importClause = "import #{selection} from './#{relative}';\n"
+		if relative[0] !== '.'
+		  relative = './' + relative
+        importClause = "import #{selection} from '#{relative}';\n"
         @addImportStatement(importClause)
 #        editor.insertText(selection + "\nimport #{selection} from './#{relative}'")
       else


### PR DESCRIPTION
The generated paths always had a hardcoded `./` prefix. This resulted in
paths like this:
`import IWow from './../foo/bar/IWow';`
While technically correct, the initial `./` is redundant, and looks a
bit silly.
I've removed the hardcoded `./` and added a check for the first
character of the relative path being a `.`. This means it will not be
added, unless the import is for a file in the same directory as the
source file, in which case it will result in `./IWow`
