### PR TITLE
Revert "Fixed incorrect import paths in Windows"

### DIFF
--- a/lib/typescript-import.coffee
+++ b/lib/typescript-import.coffee
@@ -88,7 +88,7 @@ module.exports = TypescriptImport =
       symbolLocation = @index[selection]
       if symbolLocation && selection
         fileFolder = path.resolve(filePath + '/..')
-        relative = path.relative(fileFolder, symbolLocation).replace(/\.(js|ts)$/, '').replace(/\\/g, '/')
+        relative = path.relative(fileFolder, symbolLocation).replace(/\.(js|ts)$/, '');
         importClause = "import #{selection} from './#{relative}';\n"
         @addImportStatement(importClause)
 #        editor.insertText(selection + "\nimport #{selection} from './#{relative}'")


### PR DESCRIPTION
Reverts GabiGrin/atom-typescript-modules-helper-plugin#2
Revering this in order to merge #1 first
