### PR TITLE
stricter regular-expression for detecting import-statement

### DIFF
--- a/lib/typescript-import.coffee
+++ b/lib/typescript-import.coffee
@@ -58,7 +58,7 @@ module.exports = TypescriptImport =
       editor = atom.workspace.getActiveTextEditor()
       currentText = editor.getText()
 
-      reImports = /import(.|\r|\n)+?from(.*)$/gm;
+      reImports = /\bimport\b(.|\r|\n)+?\bfrom\b(.*)$/gm;
       isDefined = false
       hasImportStatements = false;
       lastMatchIndex = 0

--- a/lib/typescript-import.coffee
+++ b/lib/typescript-import.coffee
@@ -230,6 +230,8 @@ module.exports = TypescriptImport =
 
   containsSymbol: (regexImportStatement, newSymbol) ->
     symbolStrList = @extractSymbolStringFrom(regexImportStatement)
+    if !symbolStrList #either import statement was wrongfully detected, or its imported symbols could not be extracted
+      return false
     reTest = new RegExp('\\s*' + newSymbol + '\\s*(,|$)', 'gm')
     i = 0
     size = symbolStrList.length


### PR DESCRIPTION
addresses issue #13 

 * require regular-expression for detecting import-statements to match whole words "import" and "from", i.e. avoid matches, where "import" and "from" are only sub-strings
 * avoid exception in case regular expression wrongfully detected an import-statement, or an import-statement's imported symbols could not be parsed/extracted